### PR TITLE
Change include so that harfbuzz can find graphite

### DIFF
--- a/extra/freetype-harfbuzz/build
+++ b/extra/freetype-harfbuzz/build
@@ -56,8 +56,8 @@ export CFLAGS="$CFLAGS -L$DESTDIR/usr/lib "
 export PKG_CONFIG_PATH="$DESTDIR/usr/lib/pkgconfig"
 
 # Point Harfbuzz to the Freetype files.
-export CXXFLAGS="$CXXFLAGS -I$DESTDIR/usr/include/freetype2"
-export CXXFLAGS="$CXXFLAGS -L$DESTDIR/usr/lib"
+export CXXFLAGS="$CXXFLAGS -I$DESTDIR/usr/include/"
+export CXXFLAGS="$CXXFLAGS -L$DESTDIR/usr/lib/"
 
 build_freetype -Dharfbuzz=disabled
 build_graphite


### PR DESCRIPTION
Hi there, thanks for your work on this!

In order to have `freetype-harfbuzz` build i found that i needed to change the include directory to capture includes like like `graphite2/Font.h`. I'm not confident this is the best way to fix this, or that this needs fixing in general, but in my case this was the smallest change that led to a successful build.